### PR TITLE
Ternary operation to show delete button 

### DIFF
--- a/src/pages/Levels/Form.jsx
+++ b/src/pages/Levels/Form.jsx
@@ -198,7 +198,9 @@ const LevelForm = () => {
                 })}
               </IonSelect>
             </IonItem>
-            <IonItem>
+            {level_id == '0' ? null : 
+              (
+                <IonItem>
               <IonButton slot="end" 
                           onClick={() => { 
                             setGetConfirmation({
@@ -209,6 +211,9 @@ const LevelForm = () => {
                 <IonIcon icon={trash} /> Delete this Level
               </IonButton>
             </IonItem>
+              )
+            }
+            
             {disable ? null : (
               <IonItem>
                 <IonButton type="submit">Save</IonButton>

--- a/src/pages/Levels/Form.jsx
+++ b/src/pages/Levels/Form.jsx
@@ -14,7 +14,7 @@ import {
 } from '@ionic/react'
 import { pencil, close, trash } from 'ionicons/icons'
 import React from 'react'
-import { useParams,useHistory } from 'react-router-dom'
+import { useParams, useHistory } from 'react-router-dom'
 import { PROJECT_IDS } from '../../utils/Constants'
 
 import Title from '../../components/Title'
@@ -42,7 +42,10 @@ const LevelForm = () => {
     students: 'Students',
     teachers: 'Teachers'
   })
-  const [getConfirmation, setGetConfirmation] = React.useState({status: false, onConfirm: () => {}})
+  const [getConfirmation, setGetConfirmation] = React.useState({
+    status: false,
+    onConfirm: () => {}
+  })
   const history = useHistory()
 
   React.useEffect(() => {
@@ -109,7 +112,9 @@ const LevelForm = () => {
       }).then((data) => {
         if (data) {
           showMessage(labels.level + ' updated Successfully', 'success')
-          unsetLocalCache(`shelter_${shelter_id}_project_${project_id}_level_index`)
+          unsetLocalCache(
+            `shelter_${shelter_id}_project_${project_id}_level_index`
+          )
           unsetLocalCache(`shelter_view_${shelter_id}`)
         }
       })
@@ -123,7 +128,9 @@ const LevelForm = () => {
             data.teachers = []
             setLevel(data)
             showMessage(labels.level + ' created Successfully', 'success')
-            unsetLocalCache(`shelter_${shelter_id}_project_${project_id}_level_index`)
+            unsetLocalCache(
+              `shelter_${shelter_id}_project_${project_id}_level_index`
+            )
             unsetLocalCache(`shelter_view_${shelter_id}`)
           }
         }
@@ -132,9 +139,12 @@ const LevelForm = () => {
   }
 
   const deleteLevel = () => {
-    if(level.teachers.length > 0 || level.students.length > 0) {
-      showMessage(`Please delete all teacher and students assignments from the level before deleting the level.`, 'error')
-      return false;
+    if (level.teachers.length > 0 || level.students.length > 0) {
+      showMessage(
+        `Please delete all teacher and students assignments from the level before deleting the level.`,
+        'error'
+      )
+      return false
     }
     callApi({
       url: `/levels/${level_id}`,
@@ -198,22 +208,25 @@ const LevelForm = () => {
                 })}
               </IonSelect>
             </IonItem>
-            {level_id == '0' ? null : 
-              (
-                <IonItem>
-              <IonButton slot="end" 
-                          onClick={() => { 
-                            setGetConfirmation({
-                              status:true,
-                              onConfirm: () => { deleteLevel() } 
-                            })
-                          }}>
-                <IonIcon icon={trash} /> Delete this Level
-              </IonButton>
-            </IonItem>
-              )
-            }
             
+            {level_id == '0' ? null : (
+              <IonItem>
+                <IonButton
+                  slot="end"
+                  onClick={() => {
+                    setGetConfirmation({
+                      status: true,
+                      onConfirm: () => {
+                        deleteLevel()
+                      }
+                    })
+                  }}
+                >
+                  <IonIcon icon={trash} /> Delete this Level
+                </IonButton>
+              </IonItem>
+            )}
+
             {disable ? null : (
               <IonItem>
                 <IonButton type="submit">Save</IonButton>
@@ -236,7 +249,9 @@ const LevelForm = () => {
 
               {disable ? null : (
                 <IonItem>
-                  <IonButton routerLink={`/shelters/${shelter_id}/projects/${project_id}/levels/${level_id}/add-student`}>
+                  <IonButton
+                    routerLink={`/shelters/${shelter_id}/projects/${project_id}/levels/${level_id}/add-student`}
+                  >
                     Add/Remove {labels.students} from this {labels.level}
                   </IonButton>
                 </IonItem>
@@ -255,7 +270,9 @@ const LevelForm = () => {
 
               {disable ? null : (
                 <IonItem>
-                  <IonButton routerLink={`/shelters/${shelter_id}/projects/${project_id}/batch/0/level/${level_id}/view-teachers`}>
+                  <IonButton
+                    routerLink={`/shelters/${shelter_id}/projects/${project_id}/batch/0/level/${level_id}/view-teachers`}
+                  >
                     Edit {labels.teachers} Assignment
                   </IonButton>
                 </IonItem>
@@ -274,14 +291,24 @@ const LevelForm = () => {
 
         <IonAlert
           isOpen={getConfirmation.status}
-          onDidDismiss={() => { setGetConfirmation({ status: false, onConfirm: getConfirmation.onConfirm }) }}
+          onDidDismiss={() => {
+            setGetConfirmation({
+              status: false,
+              onConfirm: getConfirmation.onConfirm
+            })
+          }}
           header={'Are you sure?'}
           subHeader={'Confirm that you wish to delete this allocation'}
           buttons={[
             {
               text: 'Cancel',
               role: 'cancel',
-              handler: () => { setGetConfirmation({ status: false, onConfirm: getConfirmation.onConfirm }) }
+              handler: () => {
+                setGetConfirmation({
+                  status: false,
+                  onConfirm: getConfirmation.onConfirm
+                })
+              }
             },
             {
               text: 'Delete',


### PR DESCRIPTION
Description: 
When creating a new class sections there is a delete button, this button should be available only when editing a class section. 

What page/module is the bug on?
Shelter > Class Section > New. Eg. https://makeadiff.in/madnet/#/shelters/244/projects/4/levels/0

![Screen Shot 2021-12-20 at 12 32 30](https://user-images.githubusercontent.com/32987141/146825149-a78831aa-a465-4d1e-9fef-ae5be6d215b5.png)

This is the ternary operation that i added to validate when is a new class section:
<img width="480" alt="Screen Shot 2021-12-20 at 9 56 06" src="https://user-images.githubusercontent.com/32987141/146825324-2a3ba406-6498-4db6-8854-0f2e4e4ef41d.png">
 
And now this is how a new section looks like without delete button
![Screen Shot 2021-12-20 at 12 38 44](https://user-images.githubusercontent.com/32987141/146825490-bf404c25-38d8-431d-bfa4-91a965770831.png)

Feel free to add some comments with feedback! 