### PR TITLE
Search users by shelter

### DIFF
--- a/src/pages/Users/Search.jsx
+++ b/src/pages/Users/Search.jsx
@@ -22,6 +22,7 @@ import './Form.css'
 const UserSearch = ({ segment }) => {
   const { user } = React.useContext(authContext)
   const [groups, setGroups] = React.useState([])
+  const [shelter, setShelter] = React.useState([])
   const [showMore, setShowMore] = React.useState(false)
   const { getUsers, callApi } = React.useContext(dataContext)
   const [users, setUsers] = React.useState(null)
@@ -31,7 +32,8 @@ const UserSearch = ({ segment }) => {
     phone: '',
     any_email: '',
     groups_in: '',
-    user_type: 'volunteer'
+    user_type: '',
+    center_id: ''
   })
 
   React.useEffect(() => {
@@ -43,6 +45,16 @@ const UserSearch = ({ segment }) => {
     fetchGroups()
   }, [segment])
 
+  //Fetching all shelters
+  React.useEffect(() => {
+    const fetchShelters = () => {
+      callApi({ url: `/cities/${search.city_id}/centers` }).then((data) => {
+        setShelter(data)
+      })
+    }
+    fetchShelters()
+  }, [segment])
+
   const setSearchValue = (key, value) => {
     const new_search = { ...search, [key]: value }
     setSearch(new_search)
@@ -51,7 +63,7 @@ const UserSearch = ({ segment }) => {
   // This converts the selected checkboxes into a coma seperated list of ids.
   const setGroupSearch = (e) => {
     let groups = []
-    if (search.group_in) groups = search.group_in.split(',')
+    if (search.groups_in) groups = search.group_in.split(',')
     const value = e.target.value
     if (e.target.checked) {
       groups.push(value)
@@ -135,6 +147,26 @@ const UserSearch = ({ segment }) => {
                     )
                   })}
                 </div>
+
+                <IonItem>
+                  <IonLabel>Shelters</IonLabel>
+                  <IonSelect
+                    value={search.center_id}
+                    placeholder="Select Shelter"
+                    interface="popover"
+                    onIonChange={(e) =>
+                      setSearchValue('center_id', e.target.value)
+                    }
+                  >
+                    {shelter.map((sh) => {
+                      return (
+                        <IonSelectOption value={sh.id}>
+                          {sh.name}
+                        </IonSelectOption>
+                      )
+                    })}
+                  </IonSelect>
+                </IonItem>
 
                 <IonItem>
                   <IonLabel>User Type</IonLabel>


### PR DESCRIPTION
As indicated in the issue, there was no possibility to filter users by Shelter. 

![Screen Shot 2021-12-22 at 14 04 04](https://user-images.githubusercontent.com/32987141/147503885-47a8bbf5-43f9-4d2f-98a1-a19b3ff76f0b.png)

First of all, I added a small function to fetch all the Shelters using the API that was provided by the owner in previous comments 

<img width="599" alt="Screen Shot 2021-12-27 at 12 59 10" src="https://user-images.githubusercontent.com/32987141/147504037-15c3da14-f900-4976-b344-049f0f39d73c.png">

Then I added a select item and added a map to show all the shelters as options to select

<img width="598" alt="Screen Shot 2021-12-27 at 12 59 39" src="https://user-images.githubusercontent.com/32987141/147504211-d579b130-6e75-4d00-8860-54ea317c9872.png">

And we get this output

![Screen Shot 2021-12-27 at 11 53 18](https://user-images.githubusercontent.com/32987141/147504290-9096849f-6471-4613-a090-45467d0b4390.png)

using the information obtained from the shelter, I used shelter Id to search for all users whose center_id is equal to shelter id. 
then in the console, we get that the selected options help us to search the users given that information. 

![Screen Shot 2021-12-27 at 13 00 27](https://user-images.githubusercontent.com/32987141/147504679-232df764-4ad6-4f0d-ba2d-81d093fa8008.png)

And finally, we can get as an output all the users that match with the given filters values. 
 
![Screen Shot 2021-12-27 at 13 00 55](https://user-images.githubusercontent.com/32987141/147504724-904178e5-4147-4d02-b7d8-f4cfd5ba1935.png)

Feel free to add some comments if it's necessary. :) 


