### PR TITLE
Added Integration tests for Resources

### DIFF
--- a/cypress/integration/resources.spec.js
+++ b/cypress/integration/resources.spec.js
@@ -1,0 +1,64 @@
+import {
+    app_url,
+    fellow_email,
+    fellow_password,
+    user_id
+} from '../secrets/config.js'
+
+describe('Resources page', () => {
+
+    it('Login to app', () => {
+        Cypress.config('defaultCommandTimeout', 10000)
+        cy.visit(app_url);
+        cy.waitForReact(1000, '#root');
+        cy.get("ion-input#email>input").type(fellow_email);
+        cy.get("ion-input#password>input").type(fellow_password).should('have.value', fellow_password);
+        cy.contains("Sign In").click();
+    
+      })
+
+    it('Link to display Resources Page', () => {
+        cy.contains('Resources').click()
+        cy.url().should('include', '/links')
+    })
+
+    it('Display list of Resources ', () => {
+        cy.contains('Website')
+        cy.contains('Make a Difference Website')
+
+        cy.contains('Personal Fundraising Link')
+        cy.contains('All the donations made using this link will automatically be tagged to you.')
+
+        cy.contains('CFR Leaderboard')
+        cy.contains('Community Fund Raising Status Dashboard / Leaderboard')
+    })
+
+    it('Validate Resources href', () => {
+        cy.contains("a", "Website")
+            .should($a => {
+            const message = $a.parent().parent().text();
+            expect($a, message).to.not.have.attr("href", "#undefined");
+        });
+
+        cy.contains("a", "Personal Fundraising Link")
+            .should($a => {
+            const message = $a.parent().parent().text();
+            expect($a, message).to.not.have.attr("href", "#undefined");
+        });
+
+        cy.contains("a", "CFR Leaderboard")
+            .should($a => {
+            const message = $a.parent().parent().text();
+            expect($a, message).to.not.have.attr("href", "#undefined");
+        });
+    })
+
+    it('URL of personal fundraising URL match the user id', () => {
+        cy.contains("a", "Personal Fundraising Link")
+            .should($a => {
+            const message = $a.parent().parent().text();
+            expect($a, message).to.have.attr("href").contain(user_id);
+        });
+    })
+})
+  


### PR DESCRIPTION
Hi! I've added some tests for Resources according to the issue #87 

The tests are applied to confirm that the list of resources is displayed correctly
<img width="1434" alt="Screen Shot 2021-12-30 at 15 46 37" src="https://user-images.githubusercontent.com/35499170/147786983-069a74a6-d8fe-4bc6-8679-952dc0f93dcc.png">

The tests also validate that the links to the resources are defined and that the fundraising url matches with the current user id
<img width="341" alt="Screen Shot 2021-12-30 at 15 50 37" src="https://user-images.githubusercontent.com/35499170/147787199-6a587a9f-23a8-41c1-933e-00106925029e.png">

**Test Summary**

- Application login
- Link to display Resources page
- Correct and complete display of the Resources list
- Defined URLs of Resources
- URL of personal fundraising URL matches the current user id

*Note: The tests consider that the file _../secrets/config.js_ contains the following information for the tests:
- The URL of the app (app_url)
- Login data of a fellow (fellow_email, fellow_password)
- The id of the current example user (user_id)

Let me know if there is anything I can improve :)



