### PR TITLE
Fixed an issue with Typescript errors - by updating the typescript lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",
     "react-scripts": "^3.4.0",
-    "typescript": "3.7.4",
+    "typescript": "3.8.3",
     "validator": "^13.7.0"
   },
   "scripts": {


### PR DESCRIPTION
It was causing a error on `npm run start` when installed from scratch.